### PR TITLE
add new versions and fix certificates

### DIFF
--- a/2.46.0/rockcraft.yaml
+++ b/2.46.0/rockcraft.yaml
@@ -46,7 +46,7 @@ parts:
       opt/prometheus/npm_licenses.tar.bz2: npm_licenses.tar.bz2
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/2.47.2/rockcraft.yaml
+++ b/2.47.2/rockcraft.yaml
@@ -46,7 +46,7 @@ parts:
       opt/prometheus/npm_licenses.tar.bz2: npm_licenses.tar.bz2
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/2.48.0/rockcraft.yaml
+++ b/2.48.0/rockcraft.yaml
@@ -46,7 +46,7 @@ parts:
       opt/prometheus/npm_licenses.tar.bz2: npm_licenses.tar.bz2
   ca-certs:
     plugin: nil
-    stage-packages: [ca-certificates]
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:

--- a/2.50.0/rockcraft.yaml
+++ b/2.50.0/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: prometheus
 summary: Prometheus in a ROCK.
 description: "Prometheus is time-series database for metrics collection and query, driven by either API or a web ui"
-version: "2.49.1"
+version: "2.50.0"
 base: ubuntu:22.04
 build-base: ubuntu:22.04
 license: Apache-2.0
@@ -17,7 +17,7 @@ parts:
     plugin: go
     source: https://github.com/prometheus/prometheus
     source-type: git
-    source-tag: "v2.49.1"
+    source-tag: "v2.50.0"
     build-snaps:
       - go/1.20/stable
       - node/20/stable

--- a/2.50.1/rockcraft.yaml
+++ b/2.50.1/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: prometheus
 summary: Prometheus in a ROCK.
 description: "Prometheus is time-series database for metrics collection and query, driven by either API or a web ui"
-version: "2.49.1"
+version: "2.50.1"
 base: ubuntu:22.04
 build-base: ubuntu:22.04
 license: Apache-2.0
@@ -17,7 +17,7 @@ parts:
     plugin: go
     source: https://github.com/prometheus/prometheus
     source-type: git
-    source-tag: "v2.49.1"
+    source-tag: "v2.50.1"
     build-snaps:
       - go/1.20/stable
       - node/20/stable


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

---

Also adding some versions from pending PRs :)

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```