### PR TITLE
fix: get the ui node version in rock-update from the new .nvmrc

### DIFF
--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -18,7 +18,7 @@ jobs:
         #   \$rockcraft_yaml: Path of the rockcraft.yaml to update
         #
         ## Node dependency
-        node_version="\$(sed -En 's|\s*"@types/node":\s*"\^*([0-9]+)(\.[0-9])+.*",|\1|p' \$application_src/web/ui/package.json)"
+        node_version="\$(grep -iE 'node(.js)?\s*>=\s*v?[0-9]+' \$application_src/web/ui/README.md | head -1 | grep -oE 'v?[0-9]+' | grep -oE '[0-9]+' | head -1)"
         yq -i 'del(.parts.prometheus.build-snaps.[] | select(. == "node/*"))' "\$rockcraft_yaml"
         ver="\$node_version" yq -i '.parts.prometheus.build-snaps += "node/"+strenv(ver)+"/stable"' "\$rockcraft_yaml"
     secrets: inherit

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -18,7 +18,7 @@ jobs:
         #   \$rockcraft_yaml: Path of the rockcraft.yaml to update
         #
         ## Node dependency
-        node_version="\$(grep -iE 'node(.js)?\s*>=\s*v?[0-9]+' \$application_src/web/ui/README.md | head -1 | grep -oE 'v?[0-9]+' | grep -oE '[0-9]+' | head -1)"
+        node_version=$(sed -E 's/^v?([0-9]+).*/\1/' "$application_src/web/ui/.nvmrc")
         yq -i 'del(.parts.prometheus.build-snaps.[] | select(. == "node/*"))' "\$rockcraft_yaml"
         ver="\$node_version" yq -i '.parts.prometheus.build-snaps += "node/"+strenv(ver)+"/stable"' "\$rockcraft_yaml"
     secrets: inherit


### PR DESCRIPTION
## Issue
Prometheus 3 no longer has the node version in [`package.json`](https://github.com/prometheus/prometheus/blob/main/web/ui/package.json). It's instead in the [`.nvmrc`](https://github.com/prometheus/prometheus/blob/aea6503d9bbaad6c5faff3ecf6f1025213356c92/web/ui/.nvmrc#L1). The current `update-rock.yaml` file tries to insert the node version into `rockcraft.yaml` by getting the node version from the package dependencies. Since this value is not found, `rockcraft.yaml` will show `node//stable` and the automatic PR for new Prometheus releases will fail.

## Solution
This PR gets the node version from `.nvmrc`, which containers one line like `v20.5.1`. The major version is extracted.


